### PR TITLE
fix: remove null parameter signatures for tap

### DIFF
--- a/lib/raven.interceptor.ts
+++ b/lib/raven.interceptor.ts
@@ -41,56 +41,58 @@ export class RavenInterceptor implements NestInterceptor {
 
     // first param would be for events, second is for errors
     return next.handle().pipe(
-      tap(null, (exception) => {
-        if (this.shouldReport(exception)) {
-          Sentry.withScope((scope) => {
-            switch (context.getType<GqlContextType>()) {
-              case 'http':
-                this.addHttpExceptionMetadatas(scope, context.switchToHttp());
-                return this.captureException(
-                  scope,
-                  exception,
-                  localTransformers,
-                );
-              case 'ws':
-                this.addWsExceptionMetadatas(scope, context.switchToWs());
-                return this.captureException(
-                  scope,
-                  exception,
-                  localTransformers,
-                );
-              case 'rpc':
-                this.addRpcExceptionMetadatas(scope, context.switchToRpc());
-                return this.captureException(
-                  scope,
-                  exception,
-                  localTransformers,
-                );
-              case 'graphql':
-                if (!GqlArgumentsHost)
+      tap({
+        error: (exception) => {
+          if (this.shouldReport(exception)) {
+            Sentry.withScope((scope) => {
+              switch (context.getType<GqlContextType>()) {
+                case 'http':
+                  this.addHttpExceptionMetadatas(scope, context.switchToHttp());
                   return this.captureException(
                     scope,
                     exception,
                     localTransformers,
                   );
-                this.addGraphQLExceptionMetadatas(
-                  scope,
-                  GqlArgumentsHost.create(context),
-                );
-                return this.captureException(
-                  scope,
-                  exception,
-                  localTransformers,
-                );
-              default:
-                return this.captureException(
-                  scope,
-                  exception,
-                  localTransformers,
-                );
-            }
-          });
-        }
+                case 'ws':
+                  this.addWsExceptionMetadatas(scope, context.switchToWs());
+                  return this.captureException(
+                    scope,
+                    exception,
+                    localTransformers,
+                  );
+                case 'rpc':
+                  this.addRpcExceptionMetadatas(scope, context.switchToRpc());
+                  return this.captureException(
+                    scope,
+                    exception,
+                    localTransformers,
+                  );
+                case 'graphql':
+                  if (!GqlArgumentsHost)
+                    return this.captureException(
+                      scope,
+                      exception,
+                      localTransformers,
+                    );
+                  this.addGraphQLExceptionMetadatas(
+                    scope,
+                    GqlArgumentsHost.create(context),
+                  );
+                  return this.captureException(
+                    scope,
+                    exception,
+                    localTransformers,
+                  );
+                default:
+                  return this.captureException(
+                    scope,
+                    exception,
+                    localTransformers,
+                  );
+              }
+            });
+          }
+        },
       }),
     );
   }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   },
   "husky": {
     "hooks": {
-      "*.ts" : [
+      "*.ts": [
         "prettier --write"
       ],
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"


### PR DESCRIPTION
closes https://github.com/mentos1386/nest-raven/issues/180

```ts
import { of } from 'rxjs';
import { tap } from 'rxjs/operators';

const source = of(3, 2, 1);

source.pipe(
  // Deprecated
  tap(null, null, () => console.log('Complete. Cookie time.'))
).subscribe(...);

source.pipe(
  // Recommended
  tap({
    complete: () => console.log('Complete. Cookie time.')
  })
).subscribe(...);
```

refs: https://dzhavat.github.io/2019/02/17/deprecations-in-rxjs-v6-4-0.html