### PR TITLE
chore(deps): upgrade/migrate sentry 7

### DIFF
--- a/example/src/gql/gql.resolver.ts
+++ b/example/src/gql/gql.resolver.ts
@@ -1,10 +1,9 @@
-import { Resolver, Query } from '@nestjs/graphql';
 import {
   ForbiddenException,
-  UseInterceptors,
   UnauthorizedException,
+  UseInterceptors,
 } from '@nestjs/common';
-import { Severity } from '@sentry/node';
+import { Query, Resolver } from '@nestjs/graphql';
 import { RavenInterceptor } from '../../../lib';
 
 @Resolver('Gql')
@@ -14,7 +13,7 @@ export class GqlResolver {
     throw new ForbiddenException();
   }
 
-  @UseInterceptors(new RavenInterceptor({ level: Severity.Warning }))
+  @UseInterceptors(new RavenInterceptor({ level: 'warning' }))
   @Query(() => Boolean)
   async unauthorizedException() {
     throw new UnauthorizedException();

--- a/lib/raven.interfaces.ts
+++ b/lib/raven.interfaces.ts
@@ -1,5 +1,5 @@
-import { Severity } from '@sentry/types';
 import { Scope } from '@sentry/node';
+import { SeverityLevel } from '@sentry/types';
 
 export interface IRavenScopeTransformerFunction {
   (scope: Scope): void;
@@ -20,7 +20,7 @@ export interface IRavenInterceptorOptions {
   tags?: { [key: string]: string };
   extra?: { [key: string]: any };
   fingerprint?: string[];
-  level?: Severity;
+  level?: SeverityLevel;
 
   // https://github.com/getsentry/sentry-javascript/blob/master/packages/node/src/handlers.ts#L163
   request?: boolean;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,10 @@
         "@nestjs/platform-socket.io": "8.4.5",
         "@nestjs/testing": "8.4.5",
         "@nestjs/websockets": "8.4.5",
-        "@sentry/minimal": "6.19.7",
-        "@sentry/node": "6.19.7",
         "@types/jest": "27.5.2",
         "@types/node": "16.11.38",
+        "@sentry/node": "^7.0.0",
+        "@sentry/types": "^7.0.0",
         "@types/supertest": "2.0.12",
         "@types/ws": "^8.5.3",
         "class-transformer": "0.5.1",
@@ -48,8 +48,8 @@
       },
       "peerDependencies": {
         "@nestjs/common": "^8.0.0",
-        "@sentry/minimal": "^6.0.4",
-        "@sentry/node": "^6.0.4",
+        "@sentry/hub": "^7.0.0",
+        "@sentry/node": "^7.0.0",
         "reflect-metadata": "^0.1.12",
         "rxjs": "^7.0.0"
       }
@@ -2033,19 +2033,18 @@
       "peer": true
     },
     "node_modules/@sentry/core": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.7.tgz",
-      "integrity": "sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.0.0.tgz",
+      "integrity": "sha512-Wl7MjmahLhuzzByYiWaYTeHKQfF6usnMp+rTTYTBbneuM4MD7TikRt6ybgnxqyqR7nI7ADH/U8OljtiqwnsOcw==",
       "dev": true,
       "dependencies": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/minimal": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
+        "@sentry/hub": "7.0.0",
+        "@sentry/types": "7.0.0",
+        "@sentry/utils": "7.0.0",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/core/node_modules/tslib": {
@@ -2055,62 +2054,40 @@
       "dev": true
     },
     "node_modules/@sentry/hub": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.7.tgz",
-      "integrity": "sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==",
-      "dev": true,
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.0.0.tgz",
+      "integrity": "sha512-my4s+SPZiL6BKOK89YNk74QFRejlwVKKSetzz+Wr1cxDLbGXOIHS3uRJlagqOpfthhD1dq8m3WBQnabPf5JlHQ==",
       "dependencies": {
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
+        "@sentry/types": "7.0.0",
+        "@sentry/utils": "7.0.0",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/hub/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
-    "node_modules/@sentry/minimal": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.7.tgz",
-      "integrity": "sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==",
-      "dev": true,
-      "dependencies": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/minimal/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/node": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.19.7.tgz",
-      "integrity": "sha512-gtmRC4dAXKODMpHXKfrkfvyBL3cI8y64vEi3fDD046uqYcrWdgoQsffuBbxMAizc6Ez1ia+f0Flue6p15Qaltg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.0.0.tgz",
+      "integrity": "sha512-YfmPldRH2oO3OCsu5kqnzVbeMa2Tr9Qf4t8iy7AuYKPok5ossIeZCBzjTBRw/g0wJL+I5WsxHVrt2YUuLGYBSQ==",
       "dev": true,
       "dependencies": {
-        "@sentry/core": "6.19.7",
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
+        "@sentry/core": "7.0.0",
+        "@sentry/hub": "7.0.0",
+        "@sentry/types": "7.0.0",
+        "@sentry/utils": "7.0.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/node/node_modules/tslib": {
@@ -2120,32 +2097,29 @@
       "dev": true
     },
     "node_modules/@sentry/types": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
-      "integrity": "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==",
-      "dev": true,
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.0.0.tgz",
+      "integrity": "sha512-im6iugKKyeOwHWiS3u+S+Ox4F6aJQ2fe76rzTDTlzdCPol4xEqYnB2kujGVVnDYrODR+qVb24ua3OsxXxwzppA==",
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.7.tgz",
-      "integrity": "sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==",
-      "dev": true,
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.0.0.tgz",
+      "integrity": "sha512-wmZNwzl1F/xCvaGX0TLz0+M+mZP8kn5woF770o2eUgXGURIuNsnSd0Vfi0nHuBJfngVeI/3+ofOJ9MH4Co4lIw==",
       "dependencies": {
-        "@sentry/types": "6.19.7",
+        "@sentry/types": "7.0.0",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/utils/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -12377,15 +12351,14 @@
       "peer": true
     },
     "@sentry/core": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.7.tgz",
-      "integrity": "sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.0.0.tgz",
+      "integrity": "sha512-Wl7MjmahLhuzzByYiWaYTeHKQfF6usnMp+rTTYTBbneuM4MD7TikRt6ybgnxqyqR7nI7ADH/U8OljtiqwnsOcw==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/minimal": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
+        "@sentry/hub": "7.0.0",
+        "@sentry/types": "7.0.0",
+        "@sentry/utils": "7.0.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -12398,53 +12371,32 @@
       }
     },
     "@sentry/hub": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.7.tgz",
-      "integrity": "sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==",
-      "dev": true,
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.0.0.tgz",
+      "integrity": "sha512-my4s+SPZiL6BKOK89YNk74QFRejlwVKKSetzz+Wr1cxDLbGXOIHS3uRJlagqOpfthhD1dq8m3WBQnabPf5JlHQ==",
       "requires": {
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
+        "@sentry/types": "7.0.0",
+        "@sentry/utils": "7.0.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
-        }
-      }
-    },
-    "@sentry/minimal": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.7.tgz",
-      "integrity": "sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==",
-      "dev": true,
-      "requires": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@sentry/node": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.19.7.tgz",
-      "integrity": "sha512-gtmRC4dAXKODMpHXKfrkfvyBL3cI8y64vEi3fDD046uqYcrWdgoQsffuBbxMAizc6Ez1ia+f0Flue6p15Qaltg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.0.0.tgz",
+      "integrity": "sha512-YfmPldRH2oO3OCsu5kqnzVbeMa2Tr9Qf4t8iy7AuYKPok5ossIeZCBzjTBRw/g0wJL+I5WsxHVrt2YUuLGYBSQ==",
       "dev": true,
       "requires": {
-        "@sentry/core": "6.19.7",
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
+        "@sentry/core": "7.0.0",
+        "@sentry/hub": "7.0.0",
+        "@sentry/types": "7.0.0",
+        "@sentry/utils": "7.0.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -12460,26 +12412,23 @@
       }
     },
     "@sentry/types": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
-      "integrity": "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==",
-      "dev": true
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.0.0.tgz",
+      "integrity": "sha512-im6iugKKyeOwHWiS3u+S+Ox4F6aJQ2fe76rzTDTlzdCPol4xEqYnB2kujGVVnDYrODR+qVb24ua3OsxXxwzppA=="
     },
     "@sentry/utils": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.7.tgz",
-      "integrity": "sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==",
-      "dev": true,
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.0.0.tgz",
+      "integrity": "sha512-wmZNwzl1F/xCvaGX0TLz0+M+mZP8kn5woF770o2eUgXGURIuNsnSd0Vfi0nHuBJfngVeI/3+ofOJ9MH4Co4lIw==",
       "requires": {
-        "@sentry/types": "6.19.7",
+        "@sentry/types": "7.0.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   },
   "peerDependencies": {
     "@nestjs/common": "^8.0.0",
-    "@sentry/minimal": "^6.0.4",
-    "@sentry/node": "^6.0.4",
+    "@sentry/hub": "^7.0.0",
+    "@sentry/node": "^7.0.0",
     "reflect-metadata": "^0.1.12",
     "rxjs": "^7.0.0"
   },
@@ -51,10 +51,10 @@
     "@nestjs/platform-socket.io": "8.4.5",
     "@nestjs/testing": "8.4.5",
     "@nestjs/websockets": "8.4.5",
-    "@sentry/minimal": "6.19.7",
-    "@sentry/node": "6.19.7",
     "@types/jest": "27.5.2",
     "@types/node": "16.11.38",
+    "@sentry/node": "^7.0.0",
+    "@sentry/types": "^7.0.0",
     "@types/supertest": "2.0.12",
     "@types/ws": "^8.5.3",
     "class-transformer": "0.5.1",

--- a/test/http/method.controller.ts
+++ b/test/http/method.controller.ts
@@ -6,7 +6,6 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { RavenInterceptor, RavenTransformer } from '../../lib';
-import * as Sentry from '@sentry/types';
 
 @Controller('')
 export class MethodController {
@@ -115,7 +114,7 @@ export class MethodController {
   @Get('level')
   @UseInterceptors(
     new RavenInterceptor({
-      level: Sentry.Severity.Critical,
+      level: 'fatal',
     }),
   )
   level() {

--- a/test/http/method.e2e.spec.ts
+++ b/test/http/method.e2e.spec.ts
@@ -1,8 +1,8 @@
-import * as request from 'supertest';
-import { Test } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
 import { getCurrentHub } from '@sentry/hub';
-import { Severity } from '@sentry/types';
+import { SeverityLevel } from '@sentry/types';
+import * as request from 'supertest';
 import { MethodModule } from './method.module';
 
 declare var global: any;
@@ -144,9 +144,9 @@ describe('Http:Method', () => {
     expect(client.captureException.mock.calls[0][0]).toMatchInlineSnapshot(
       `[Error: Something bad happened]`,
     );
-    expect(client.captureException.mock.calls[0][2]._level).toEqual(
-      Severity.Critical,
-    );
+    expect(
+      client.captureException.mock.calls[0][2]._level,
+    ).toEqual<SeverityLevel>('fatal');
   });
 
   afterAll(async () => {


### PR DESCRIPTION
Hello, here I'm just upgrading Sentry to v7 after reading the migration notes > https://github.com/getsentry/sentry-javascript/blob/7.0.0/MIGRATION.md#upgrading-from-6x-to-7x. I did run the tests and they passed. Feedback is very welcome.