### PR TITLE
Bump v9.0.0

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [lts/*, latest]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     # Setup .npmrc file to publish to npm
     - uses: actions/setup-node@v1
       with:
-        node-version: '16.x'
+        node-version: 'lts/*'
         registry-url: 'https://registry.npmjs.org'
     - run: npm install
     - run: npm publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-raven",
-  "version": "8.2.0",
+  "version": "9.0.0",
   "description": "Sentry Raven Module for Nest Framework",
   "files": [
     "dist"


### PR DESCRIPTION
closes https://github.com/mentos1386/nest-raven/issues/448

related https://github.com/mentos1386/nest-raven/pull/437

- upgrade package version
- `lts/*` test support