### PR TITLE
[FEATURE] Add execution context in transformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,11 @@ dynamically.
   @UseInterceptors(new RavenInterceptor({
     transformers: [
         // Add an extra property to Sentry's scope
-        (scope: Scope) => { scope.addExtra('important key', 'useful value') }
+        (scope: Scope, context: ExecutionContext) => {
+          const req = context.switchToHttp().getRequest<Request>();
+          scope.addExtra('important query', req.query.important_query)
+          scope.addExtra('important key', 'useful value');
+        }
     ],
   }))
   @Get('/some/route')

--- a/lib/raven.interceptor.ts
+++ b/lib/raven.interceptor.ts
@@ -50,6 +50,7 @@ export class RavenInterceptor implements NestInterceptor {
                     scope,
                     exception,
                     localTransformers,
+                    context,
                   );
                 case 'ws':
                   this.addWsExceptionMetadatas(scope, context.switchToWs());
@@ -57,6 +58,7 @@ export class RavenInterceptor implements NestInterceptor {
                     scope,
                     exception,
                     localTransformers,
+                    context,
                   );
                 case 'rpc':
                   this.addRpcExceptionMetadatas(scope, context.switchToRpc());
@@ -64,6 +66,7 @@ export class RavenInterceptor implements NestInterceptor {
                     scope,
                     exception,
                     localTransformers,
+                    context,
                   );
                 case 'graphql':
                   if (!GqlArgumentsHost)
@@ -71,6 +74,7 @@ export class RavenInterceptor implements NestInterceptor {
                       scope,
                       exception,
                       localTransformers,
+                      context,
                     );
                   this.addGraphQLExceptionMetadatas(
                     scope,
@@ -80,12 +84,14 @@ export class RavenInterceptor implements NestInterceptor {
                     scope,
                     exception,
                     localTransformers,
+                    context,
                   );
                 default:
                   return this.captureException(
                     scope,
                     exception,
                     localTransformers,
+                    context,
                   );
               }
             });
@@ -145,6 +151,7 @@ export class RavenInterceptor implements NestInterceptor {
     scope: Scope,
     exception: any,
     localTransformers: IRavenScopeTransformerFunction[] | undefined,
+    context: ExecutionContext,
   ): void {
     if (this.options.level) scope.setLevel(this.options.level);
     if (this.options.fingerprint)
@@ -153,9 +160,11 @@ export class RavenInterceptor implements NestInterceptor {
     if (this.options.tags) scope.setTags(this.options.tags);
 
     if (this.options.transformers)
-      this.options.transformers.forEach((transformer) => transformer(scope));
+      this.options.transformers.forEach((transformer) =>
+        transformer(scope, context),
+      );
     if (localTransformers)
-      localTransformers.forEach((transformer) => transformer(scope));
+      localTransformers.forEach((transformer) => transformer(scope, context));
 
     captureException(exception);
   }

--- a/lib/raven.interfaces.ts
+++ b/lib/raven.interfaces.ts
@@ -1,8 +1,9 @@
+import { ExecutionContext } from '@nestjs/common';
 import { Scope } from '@sentry/node';
 import { SeverityLevel } from '@sentry/types';
 
 export interface IRavenScopeTransformerFunction {
-  (scope: Scope): void;
+  (scope: Scope, context: ExecutionContext): void;
 }
 
 export interface IRavenFilterFunction {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nest-raven",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nest-raven",
-      "version": "9.0.0",
+      "version": "9.0.1",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "17.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nest-raven",
-  "version": "9.0.1",
+  "version": "9.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nest-raven",
-      "version": "9.0.1",
+      "version": "9.1.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "17.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-raven",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Sentry Raven Module for Nest Framework",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-raven",
-  "version": "9.0.1",
+  "version": "9.1.0",
   "description": "Sentry Raven Module for Nest Framework",
   "files": [
     "dist"

--- a/test/http/method.controller.ts
+++ b/test/http/method.controller.ts
@@ -5,6 +5,7 @@ import {
   HttpStatus,
   UseInterceptors,
 } from '@nestjs/common';
+import { Request } from 'express';
 import { RavenInterceptor, RavenTransformer } from '../../lib';
 
 @Controller('')
@@ -45,8 +46,10 @@ export class MethodController {
   @UseInterceptors(
     new RavenInterceptor({
       transformers: [
-        (scope) => {
+        (scope, context) => {
+          const req = context.switchToHttp().getRequest<Request>();
           scope.setExtra('A', 'AAA');
+          scope.setExtra('REQ', req.query.foo);
         },
       ],
     }),

--- a/test/http/method.e2e.spec.ts
+++ b/test/http/method.e2e.spec.ts
@@ -59,7 +59,7 @@ describe('Http:Method', () => {
   });
 
   it(`/GET transformer`, async () => {
-    await request(app.getHttpServer()).get('/transformer').expect(500);
+    await request(app.getHttpServer()).get('/transformer?foo=bar').expect(500);
 
     expect(client.captureException.mock.calls[0][0]).toMatchInlineSnapshot(
       `[Error: Something bad happened]`,
@@ -67,6 +67,10 @@ describe('Http:Method', () => {
     expect(client.captureException.mock.calls[0][2]._extra).toHaveProperty(
       'A',
       'AAA',
+    );
+    expect(client.captureException.mock.calls[0][2]._extra).toHaveProperty(
+      'REQ',
+      'bar',
     );
   });
 


### PR DESCRIPTION
Adds execution context in transformer so that we can set sentry scope properties based on what's available in the execution context. e.g. setting a query param from request context as a sentry tag