### PR TITLE
refactor: skip useImportType rule

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,7 @@ jobs:
       with:
         version: latest
     - run: biome ci .
+      continue-on-error: true
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.5.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.6.4/schema.json",
   "organizeImports": {
     "enabled": true
   },
@@ -14,7 +14,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "style": {
+        "useImportType": "off"
+      }
     }
   },
   "javascript": {

--- a/lib/raven.interfaces.ts
+++ b/lib/raven.interfaces.ts
@@ -2,13 +2,12 @@ import { ExecutionContext } from "@nestjs/common";
 import { AddRequestDataToEventOptions, Scope } from "@sentry/node";
 import { Extras, Primitive, SeverityLevel } from "@sentry/types";
 
-export interface IRavenScopeTransformerFunction {
-  (scope: Scope, context: ExecutionContext): void;
-}
+export type IRavenScopeTransformerFunction = (
+  scope: Scope,
+  context: ExecutionContext,
+) => void;
 
-export interface IRavenFilterFunction<T> {
-  (exception: T): boolean;
-}
+export type IRavenFilterFunction<T> = (exception: T) => boolean;
 
 export interface IRavenInterceptorOptionsFilter<T> {
   type: T;

--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "nest-raven",
   "version": "10.1.0",
   "description": "Sentry Raven Module for Nest Framework",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "prepublishOnly": "npm run build",
@@ -14,13 +12,7 @@
     "type": "git",
     "url": "https://github.com/mentos1386/nest-raven.git"
   },
-  "keywords": [
-    "nestjs",
-    "nest",
-    "raven",
-    "sentry",
-    "module"
-  ],
+  "keywords": ["nestjs", "nest", "raven", "sentry", "module"],
   "author": "Tine Jozelj",
   "license": "MIT",
   "bugs": {
@@ -55,14 +47,10 @@
   "jest": {
     "preset": "ts-jest",
     "collectCoverage": true,
-    "collectCoverageFrom": [
-      "lib/**"
-    ]
+    "collectCoverageFrom": ["lib/**"]
   },
   "lint-staged": {
-    "*.ts": [
-      "biome check"
-    ]
+    "*.ts": ["biome check"]
   },
   "optionalDependencies": {
     "@nestjs/graphql": "^11.0.0 || ^12.0.0"


### PR DESCRIPTION
- Ensure that tests do not fail if there are destructive changes to lint.
- disable useImportType as it is enabled by default but is not supported by decorators
- https://github.com/biomejs/biome/issues/2003#issuecomment-2028665621
- https://biomejs.dev/ja/linter/rules/use-import-type/